### PR TITLE
Fix pprof fatal log formatting

### DIFF
--- a/3_optimize_ws_goroutines/server.go
+++ b/3_optimize_ws_goroutines/server.go
@@ -32,7 +32,7 @@ func main() {
 	// Enable pprof hooks
 	go func() {
 		if err := http.ListenAndServe("localhost:6060", nil); err != nil {
-			log.Fatalf("Pprof failed:", err)
+			log.Fatalf("Pprof failed: %v", err)
 		}
 	}()
 

--- a/4_optimize_gobwas/server.go
+++ b/4_optimize_gobwas/server.go
@@ -32,7 +32,7 @@ func main() {
 	// Enable pprof hooks
 	go func() {
 		if err := http.ListenAndServe("localhost:6060", nil); err != nil {
-			log.Fatalf("Pprof failed:", err)
+			log.Fatalf("Pprof failed: %v", err)
 		}
 	}()
 


### PR DESCRIPTION
## Summary
- format pprof failure logging to include the error details in goroutine-based server examples
- apply the same fix to the gobwas-based optimized server

## Testing
- go test ./... *(fails: pattern ./...: directory prefix . does not contain main module or its selected dependencies)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692811b610208331b546406c4fbf76d5)